### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/script.js
+++ b/script.js
@@ -86,7 +86,7 @@ function escapeHtml(unsafe) {
 
 function sanitizeHtml(html) {
     const div = document.createElement('div');
-    div.innerHTML = html;
+    div.innerHTML = escapeHtml(html); // Escape input before assigning to innerHTML
 
     const allowedTags = new Set(['p', 'b', 'i', 'u', 'em', 'strong', 'span', 'div', 'br', 'pre', 'code', 'a', 'img', 'ul', 'ol', 'li', 'blockquote']);
     const safeAttributes = new Set(['href', 'src', 'alt', 'title', 'class', 'style', 'data-*']);


### PR DESCRIPTION
Potential fix for [https://github.com/localhost-four/anon/security/code-scanning/11](https://github.com/localhost-four/anon/security/code-scanning/11)

To fix the issue, we need to ensure that untrusted user input is safely escaped before being assigned to `div.innerHTML`. Instead of assigning the raw input directly, we will use the `escapeHtml()` function to escape meta-characters (e.g., `<`, `>`, `&`, etc.) before further sanitizing the HTML.

This ensures that even if `sanitizeHtml()` has a flaw, the input is already escaped, reducing the risk of XSS. Additionally:
- Modify the `sanitizeHtml()` function to escape the input before assigning it to `div.innerHTML`.
- Ensure that all intermediate transformations handle potentially unsafe input safely.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
